### PR TITLE
Permanent penalties + report fixes, part 1

### DIFF
--- a/kotoed-js/src/main/ts/data/submission.ts
+++ b/kotoed-js/src/main/ts/data/submission.ts
@@ -24,6 +24,7 @@ export interface BloatSubmission extends SubmissionToRead {
 // This is here because of possible problems with cyclic imports
 export interface JumboProject extends BloatProject {
     openSubmissions: Array<SubmissionToRead & WithVerificationData>
+    permanentAdjustment: number
 }
 
 export interface CreateRequest {

--- a/kotoed-js/src/main/ts/data/submission.ts
+++ b/kotoed-js/src/main/ts/data/submission.ts
@@ -25,6 +25,7 @@ export interface BloatSubmission extends SubmissionToRead {
 export interface JumboProject extends BloatProject {
     openSubmissions: Array<SubmissionToRead & WithVerificationData>
     permanentAdjustment: number
+    permanentAdjustmentSubmissions: Array<SubmissionToRead & WithVerificationData>
 }
 
 export interface CreateRequest {

--- a/kotoed-js/src/main/ts/projects/list.tsx
+++ b/kotoed-js/src/main/ts/projects/list.tsx
@@ -73,7 +73,14 @@ class ProjectComponent extends React.PureComponent<ProjectWithVer> {
     };
 
     private renderPermanentAdjustment = (): JSX.Element => {
-        return <span>{this.props.permanentAdjustment != 0 && <p>Permanent adj. {this.props.permanentAdjustment}</p>}</span>
+        return <span>{this.props.permanentAdjustment !== 0 &&
+        <p>Permanent adjustment {this.props.permanentAdjustment} by
+            {this.props.permanentAdjustmentSubmissions
+                .map((sub) =>
+                    <span> {linkToSubmissionDetails(sub)}</span>
+                )
+            }</p>}
+        </span>
     }
 
     private renderOpenSubmissions = (): JSX.Element => {

--- a/kotoed-js/src/main/ts/projects/list.tsx
+++ b/kotoed-js/src/main/ts/projects/list.tsx
@@ -67,10 +67,14 @@ class ProjectComponent extends React.PureComponent<ProjectWithVer> {
     handleSearchableClick = (word: string) => {
         const searchState = this.props.cb();
         // XXX: we can do better
-        if(!searchState.oldKey.includes(word)) {
+        if (!searchState.oldKey.includes(word)) {
             searchState.toggleSearch(searchState.oldKey + " " + word)
         }
     };
+
+    private renderPermanentAdjustment = (): JSX.Element => {
+        return <span>{this.props.permanentAdjustment != 0 && <p>Permanent adj. {this.props.permanentAdjustment}</p>}</span>
+    }
 
     private renderOpenSubmissions = (): JSX.Element => {
         if (this.props.openSubmissions.length === 0)
@@ -79,13 +83,13 @@ class ProjectComponent extends React.PureComponent<ProjectWithVer> {
             // Yes, super-minimalistic table
             return <table>
                 <tbody>
-                    {this.props.openSubmissions.map((sub) => <tr className="roomy-tr" key={`submission-${sub.id}`}>
-                        <td>{linkToSubmissionDetails(sub)}</td>
-                        <td>{linkToSubmissionResults(sub)}</td>
-                        <td>{linkToSubmissionReview(sub)}</td>
-                        <td>{renderSubmissionIcon(sub)}</td>
-                        <td>{renderSubmissionTags(sub, this.handleSearchableClick)}</td>
-                    </tr>)}
+                {this.props.openSubmissions.map((sub) => <tr className="roomy-tr" key={`submission-${sub.id}`}>
+                    <td>{linkToSubmissionDetails(sub)}</td>
+                    <td>{linkToSubmissionResults(sub)}</td>
+                    <td>{linkToSubmissionReview(sub)}</td>
+                    <td>{renderSubmissionIcon(sub)}</td>
+                    <td>{renderSubmissionTags(sub, this.handleSearchableClick)}</td>
+                </tr>)}
                 </tbody>
             </table>
         }
@@ -116,7 +120,8 @@ class ProjectComponent extends React.PureComponent<ProjectWithVer> {
             <a href={Kotoed.UrlPattern.reverse(Kotoed.UrlPattern.Profile.Index, {id: denizen.id})}>
                 {fullName || `#${denizen.id}`}
             </a>;
-        let groupLink = group && <a style={{cursor: "pointer"}} onClick={() => this.handleSearchableClick(group)}>{group}</a>;
+        let groupLink = group &&
+            <a style={{cursor: "pointer"}} onClick={() => this.handleSearchableClick(group)}>{group}</a>;
 
         return <span>
             ({nameLink}{groupLink && <span>, {groupLink}</span> || null})
@@ -139,7 +144,7 @@ class ProjectComponent extends React.PureComponent<ProjectWithVer> {
             <td>{this.linkify(truncateString(this.props.name || "", 30))}{" "}{this.renderIcon()}</td>
             <td>{this.renderProfileLinks(this.props.denizen)}</td>
             <td><a href={this.props.repoUrl}>Link</a></td>
-            <td>{this.renderOpenSubmissions()}</td>
+            <td>{this.renderPermanentAdjustment()}{this.renderOpenSubmissions()}</td>
         </tr>
     }
 
@@ -153,7 +158,7 @@ interface ProjectSearchState {
 }
 
 class ProjectsSearchTable extends ChoosyByVerDataSearchTable<JumboProject & WithVerificationData,
-        {withVerificationData: true, find: {courseId: number }}> {
+    { withVerificationData: true, find: { courseId: number } }> {
 
     protected isGoodEnough(data: (JumboProject & WithVerificationData)[]) {
         return super.isGoodEnough(data) &&
@@ -200,16 +205,16 @@ class ProjectsSearch extends React.Component<{}, ProjectSearchState> {
 
     toolbarButtons = (cb: SearchCallback) => {
         return <ButtonToolbar>
-            { this.state.canEditCourse &&
-                <Button bsStyle={"link"} href={UrlPattern.reverse(UrlPattern.Course.Edit, {id: id_})}>
-                    Edit course
-                </Button>
+            {this.state.canEditCourse &&
+            <Button bsStyle={"link"} href={UrlPattern.reverse(UrlPattern.Course.Edit, {id: id_})}>
+                Edit course
+            </Button>
             }
-            { this.state.canCreateProject &&
-                <ProjectCreate onCreate={() => {
-                    const search = cb();
-                    search.toggleSearch(search.oldKey)
-                }} courseId={id_}/>
+            {this.state.canCreateProject &&
+            <ProjectCreate onCreate={() => {
+                const search = cb();
+                search.toggleSearch(search.oldKey)
+            }} courseId={id_}/>
             }
         </ButtonToolbar>;
     };
@@ -217,14 +222,16 @@ class ProjectsSearch extends React.Component<{}, ProjectSearchState> {
     tagCloug = (cb: SearchCallback) => {
         return this.state.tags.length !== 0 && <Row>
             <Col xs={12} sm={12} md={12} lg={12}>
-                {intersperse<JSX.Element | string>(this.state.tags.map(tag => <TagComponent key={tag.id} tag={tag} removable={false} onClick={() => {
-                    const searchState = cb();
-                    // XXX: we can do better
-                    // XXX: also it's a copy-paste from ProjectComponent
-                    if(!searchState.oldKey.includes(tag.name)) {
-                        searchState.toggleSearch(searchState.oldKey + " " + tag.name)
-                    }
-                }}/>), " ")}
+                {intersperse<JSX.Element | string>(this.state.tags.map(tag => <TagComponent key={tag.id} tag={tag}
+                                                                                            removable={false}
+                                                                                            onClick={() => {
+                                                                                                const searchState = cb();
+                                                                                                // XXX: we can do better
+                                                                                                // XXX: also it's a copy-paste from ProjectComponent
+                                                                                                if (!searchState.oldKey.includes(tag.name)) {
+                                                                                                    searchState.toggleSearch(searchState.oldKey + " " + tag.name)
+                                                                                                }
+                                                                                            }}/>), " ")}
             </Col>
         </Row>;
     };
@@ -254,16 +261,16 @@ class ProjectsSearch extends React.Component<{}, ProjectSearchState> {
         return (
             <Table striped bordered condensed hover responsive>
                 <thead>
-                    <tr>
-                        <th className="col-md-1">Id</th>
-                        <th className="col-md-2">Name</th>
-                        <th className="col-md-3">Author</th>
-                        <th className="col-md-1">Repo</th>
-                        <th className="col-md-5">Open submissions</th>
-                    </tr>
+                <tr>
+                    <th className="col-md-1">Id</th>
+                    <th className="col-md-2">Name</th>
+                    <th className="col-md-3">Author</th>
+                    <th className="col-md-1">Repo</th>
+                    <th className="col-md-5">Open submissions</th>
+                </tr>
                 </thead>
                 <tbody>
-                    {children}
+                {children}
                 </tbody>
             </Table>)
     };
@@ -293,7 +300,9 @@ class ProjectsSearch extends React.Component<{}, ProjectSearchState> {
                             }
                         }}
                         wrapResults={this.renderTable}
-                        elementComponent={(key, c: ProjectWithVer, cb: SearchCallback) => <ProjectComponent {...c} key={key} cb={cb} />}
+                        elementComponent={(key, c: ProjectWithVer, cb: SearchCallback) => <ProjectComponent {...c}
+                                                                                                            key={key}
+                                                                                                            cb={cb}/>}
                         toolbarComponent={this.toolbar}
                     />
                 </Row>
@@ -310,7 +319,7 @@ if (params == null) {
 
 let id = params.get("id");
 
-if (id === undefined ) {
+if (id === undefined) {
     snafuDialog();
     throw new Error("Cannot resolve course id")
 }

--- a/kotoed-server/src/main/resources/db/migration/V83__Permanent_penalty_tag.sql
+++ b/kotoed-server/src/main/resources/db/migration/V83__Permanent_penalty_tag.sql
@@ -1,0 +1,2 @@
+INSERT INTO tag (id, name, style)
+VALUES (DEFAULT, 'permanent', '{"color": "brown", "backgroundColor": "orange"}');


### PR DESCRIPTION
Что есть:

1) Исправления для отчёта (учёт флага checked)
2) Отображение перманентных штрафов/бонусов в интерфейсе (в списке проектов)
3) Отображение перманентных штрафов/бонусов в отчёте

Как всё это выглядит:
![image](https://user-images.githubusercontent.com/3375923/98374428-b40b2080-2051-11eb-8d36-69dcf91c149a.png)

Что ещё не успел сделать:

1) Показ перманентных тегов только для преподавателей
2) Предупреждение при попытке закрытия сабмишна с тегами-штрафами, но без тега permanent

В UI-части перекосилось форматирование кода после идеевского Reformat Code, я в курсе этого.